### PR TITLE
Master

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -127,6 +127,7 @@ h1,h2,h4,h5,h6 {
 			height: 350px;
 			position: absolute;
 			top: 0;
+			pointer-events: none;
 		}
 			#grad_left {
 		        left: 0;

--- a/css/style_v.css
+++ b/css/style_v.css
@@ -127,6 +127,7 @@ h1,h2,h4,h5,h6 {
 			width: 500px;
 			height: 80px;
 			position: absolute;
+			pointer-events: none;
 		}
 			#grad_top {
 		        top: 0;


### PR DESCRIPTION
Browsers who support pointer-events (all modern browsers and IE 11+) have no click-death-area in the edges where the gradient-PNG's covers the dates-nav. So it's possible to have the link-pointer on the full navigation with.